### PR TITLE
added jinja2_htmltemplate.loaders.FileSystemLoader()

### DIFF
--- a/jinja2_htmltemplate/loaders.py
+++ b/jinja2_htmltemplate/loaders.py
@@ -1,0 +1,8 @@
+import jinja2.loaders as jinja2_loaders
+from jinja2_htmltemplate.translate import HtmlTemplate
+
+
+class FileSystemLoader(jinja2_loaders.FileSystemLoader):
+    def get_source(self, environment, template):
+        source, filename, uptodate = super().get_source(environment, template)
+        return HtmlTemplate().from_string(source), filename, uptodate

--- a/tests/res/templates/filesystem_loader.html
+++ b/tests/res/templates/filesystem_loader.html
@@ -1,0 +1,9 @@
+<html>
+  <head><title><TMPL_VAR NAME="title"></title></head>
+  <body>
+    <h1><TMPL_VAR NAME="title"></h1>
+    <ol>
+      <TMPL_LOOP NAME="items"><li><TMPL_VAR NAME="name"></li></TMPL_LOOP>
+    </ol>
+  </body>
+</html>

--- a/tests/test_jinja_file_system_loader.py
+++ b/tests/test_jinja_file_system_loader.py
@@ -1,0 +1,39 @@
+from nose.tools import ok_, eq_, raises
+from jinja2 import Environment
+from jinja2_htmltemplate.loaders import FileSystemLoader
+from jinja2.exceptions import TemplateNotFound
+
+
+def test_basic():
+    env = Environment(loader=FileSystemLoader('tests/res/templates/'))
+
+    t = env.get_template('filesystem_loader.html')
+    ok_(t, msg='FileSystemLoader get_template')
+    
+    out = t.render(title='Hello World!', items=[{'name': 'item 1'}, {'name': 'item 2'}])
+    eq_(out, '''<html>
+  <head><title>Hello World!</title></head>
+  <body>
+    <h1>Hello World!</h1>
+    <ol>
+      <li>item 1</li><li>item 2</li>
+    </ol>
+  </body>
+</html>''', msg='render via FileSystemLoader#1')
+    
+    out = t.render(title='HTML::Template FileSystemLoader', items=[{'name': 'Hello World!'}])
+    eq_(out, '''<html>
+  <head><title>HTML::Template FileSystemLoader</title></head>
+  <body>
+    <h1>HTML::Template FileSystemLoader</h1>
+    <ol>
+      <li>Hello World!</li>
+    </ol>
+  </body>
+</html>''', msg='render via FileSystemLoader#2')
+
+
+@raises(TemplateNotFound)
+def test_nonexistent_templates():
+    env = Environment(loader=FileSystemLoader('tests/res/templates/'))
+    env.get_template('not_exists.html')


### PR DESCRIPTION
HTML::Templateファイルをjinja2  TemplateオブジェクトとしてロードするFileSystemLoaderを追加
```
from jinja2_htmltemplate.loaders import FileSystemLoader

env = Environment(loader=FileSystemLoader('tests/res/templates/'))
t = env.get_template('filesystem_loader.html')
t.render(....)
```
