### PR TITLE
support '<TMPL_INCLUDE>'

### DIFF
--- a/jinja2_htmltemplate/translate.py
+++ b/jinja2_htmltemplate/translate.py
@@ -62,6 +62,8 @@ class HtmlTemplate(object):
                 handler.tmpl_loop(token[TokenIndex.NAME])
             elif token[TokenIndex.TYPE] == Tokens.TMPL_LOOP_END:
                 handler.tmpl_loop_end()
+            elif token[TokenIndex.TYPE] == Tokens.TMPL_INCLUDE:
+                handler.tmpl_include(token[TokenIndex.NAME])
             elif token[TokenIndex.TYPE] == Tokens.TMPL_IF:
                 handler.tmpl_if(token[TokenIndex.NAME])
             elif token[TokenIndex.TYPE] == Tokens.TMPL_IF_END:
@@ -73,7 +75,7 @@ class HtmlTemplate(object):
             elif token[TokenIndex.TYPE] == Tokens.TMPL_UNLESS_END:
                 handler.tmpl_unless_end()
             else:
-                handler.unknown(token[TokenIndex.TEXT])
+                handler.tmpl_unknown(token[TokenIndex.TEXT])
         return handler.get_template()
 
     def _parse_tmpl_token(self, token):
@@ -169,6 +171,9 @@ class TokenHandler(object):
     def tmpl_loop_end(self):
         self.append("{% endfor %}")
         self.stack.pop()
+
+    def tmpl_include(self, name):
+        self.append('{% include "' + name + '" %}')
 
     def tmpl_if(self, name):
         self.append('{% if ' + name +  ' %}')

--- a/tests/res/templates/include_base.html
+++ b/tests/res/templates/include_base.html
@@ -1,0 +1,1 @@
+<html><head><TMPL_INCLUDE NAME="templates/include_target.html"></head><body><h1><TMPL_VAR NAME="message"></h1></body></html>

--- a/tests/res/templates/include_target.html
+++ b/tests/res/templates/include_target.html
@@ -1,0 +1,1 @@
+<title><TMPL_VAR NAME="title"></title>

--- a/tests/test_jinja_include.py
+++ b/tests/test_jinja_include.py
@@ -1,0 +1,11 @@
+from nose.tools import eq_
+from jinja2 import Environment
+from jinja2_htmltemplate.loaders import FileSystemLoader
+
+
+def test_include():
+    env = Environment(loader=FileSystemLoader('tests/res'))
+    t = env.get_template('templates/include_base.html')
+    out = t.render(title='Hello, Include!', message='Hello World!')
+    eq_('<html><head><title>Hello, Include!</title></head><body><h1>Hello World!</h1></body></html>', out)
+    print(out)

--- a/tests/test_tmpl_include.py
+++ b/tests/test_tmpl_include.py
@@ -1,0 +1,8 @@
+from nose.tools import eq_
+from jinja2_htmltemplate.translate import HtmlTemplate
+
+
+def test_tmpl_include():
+    t = HtmlTemplate()
+    out = t.from_string('<TMPL_INCLUDE NAME="foo.html">')
+    eq_('{% include "foo.html" %}', out)


### PR DESCRIPTION
INCLUDEをサポート。

実際のincludeの処理はjinja側に行わさせる。
jinja2_htmltemplate.loaders.FileSystemLoaderをEnvironmentにセットして使用する。


### ベースのテンプレート `/path/to/html/templates/base.html`
```base.html
<html><TMPL_INCLUDE NAME="target.html"><body><TMPL_VAR NAME="message"></body></html>
```
### includeされるテンプレート `/path/to/html/templates/target.html`
```target.html
<head><title><TMPL_VAR NAME="title"></title></head>
```

### レンダリング
```
from jinja2 import Environment
from jinja2_htmltemplate.loaders import FileSystemLoader

env = Environment(loader=FileSystemLoader('/path/to/html/templates'))
t = env.get_template('base.html')
t.render(title='Hello, Include!', message='World!')
# <html><head><title>Hello, Include!</title></head><body>World!</body></html>
```